### PR TITLE
Mal deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,25 @@ __pycache__/
 *.json
 *.db
 
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
 # Unignore
 !/tests/test_data/.travis_postgres.json
 !/setup.py

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,7 +17,7 @@ Default Logger
 
 Minoshiro
 --------------------
-.. py:class:: Minoshiro(db_controller, mal_config, \*, logger=None, loop=None)
+.. py:class:: Minoshiro(db_controller, \*, logger=None, loop=None)
 
     Represents the search instance.
 
@@ -32,18 +32,6 @@ Minoshiro
     * db_controller(:py:class:`DataController`) -
       Any sub class of :py:class:`DataController` will work here.
 
-    * mal_config(:py:class:`dict`) - A dict for MAL authorization.
-        It must contain the keys:
-            ``user``: Your MAL username
-
-            ``password``: Your MAL password
-
-        It may also contain a key ``description`` for the description you
-        wish to use in the auth header.
-
-        If this key is not present, the description defaults to:
-        ``A Python library for anime search.``
-
     * logger(Optional[:py:class:`logging.Logger`]) -  The logger object.
       If it's not provided, will use the defualt logger provided by the library.
 
@@ -52,7 +40,7 @@ Minoshiro
       An asyncio event loop. If not provided will use the default event loop.
 
 
-    .. py:classmethod:: from_postgres(mal_config, db_config = None, pool=None, \*, schema='minoshiro', cache_pages=0, cache_mal_entries=0, logger=None, loop=None)
+    .. py:classmethod:: from_postgres( db_config = None, pool=None, \*, schema='minoshiro', cache_pages=0, logger=None, loop=None)
 
         This method is a *coroutine*
 
@@ -60,18 +48,6 @@ Minoshiro
         :py:class:`PostgresController` as the database controller.
 
         **Parameters**
-
-        * mal_config(:py:class:`dict`) - A dict for MAL authorization.
-            It must contain the keys:
-                ``user``: Your MAL username
-
-                ``password``: Your MAL password
-
-            It may also contain a key ``description`` for the description you
-            wish to use in the auth header.
-
-            If this key is not present, the description defaults to:
-            ``A Python library for anime search.``
 
         * db_config(:py:class:`dict`) -
           A dict of database config for the connection.
@@ -103,10 +79,6 @@ Minoshiro
           manga from Anilist to cache before the instance is created.
           Each page contains 40 entries max.
 
-        * cache_mal_entries(Optional[:py:class:`int`]) -
-          The number of MAL entries you wish to cache.
-          ``cache_pages`` must be greater than 0 to cache MAL entries.
-
         * logger(Optional[:py:class:`logging.Logger`]) -  The logger object.
           If it's not provided, will use the defualt logger
           provided by the library.
@@ -120,7 +92,7 @@ Minoshiro
         Instance of :py:class:`Minoshiro` with
         :py:class:`PostgresController` as the database controller.
 
-    .. py:classmethod:: from_sqlite(mal_config, path, \*, cache_pages=0, cache_mal_entries=0, logger=None, loop=None)
+    .. py:classmethod:: from_sqlite(path, \*, cache_pages=0, logger=None, loop=None)
 
         This method is a *coroutine*
 
@@ -129,18 +101,6 @@ Minoshiro
 
         **Parameters**
 
-        * mal_config(:py:class:`dict`) - A dict for MAL authorization.
-            It must contain the keys:
-                ``user``: Your MAL username
-
-                ``password``: Your MAL password
-
-            It may also contain a key ``description`` for the description you
-            wish to use in the auth header.
-
-            If this key is not present, the description defaults to:
-            ``A Python library for anime search.``
-
         * path(Union[:py:class:`str`, :py:class:`pathlib.Path`]) -
           The path to the SQLite3 database,
           can either be a string or a Pathlib Path object.
@@ -148,11 +108,6 @@ Minoshiro
         * cache_pages(Optional[:py:class:`int`]) -  The number of pages of
           anime and manga from Anilist to cache before the instance is created.
           Each page contains 40 entries max.
-
-        * cache_mal_entries(Optional[:py:class:`int`]) -
-          The number of MAL entries
-          you wish to cache. ``cache_pages`` must be greater than
-          0 to cache MAL entries.
 
         * logger(Optional[:py:class:`logging.Logger`]) -
           The logger object. If it's not provided,
@@ -168,7 +123,7 @@ Minoshiro
         Instance of :py:class:`Minoshiro` with
         :py:class:`PostgresController` as the database controller.
 
-    .. py:method:: pre_cache(cache_pages, cache_mal_entries)
+    .. py:method:: pre_cache(cache_pages)
 
         This method is a *coroutine*
 
@@ -182,9 +137,6 @@ Minoshiro
 
         * cache_pages(:py:class:`int`) - Number of Anilist pages to cache.
           There are 40 entries per page.
-
-        * cache_mal_entries(:py:class:`int`) -
-          Number of MAL entries you wish to cache.
 
     .. py:method:: yield_data(query, medium, sites, *, timeout=3)
 

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -16,14 +16,10 @@ such:
     from minoshiro import Minoshiro
 
     async def main():
-        mal_config = {
-            'user': 'MAL User name',
-            'password': 'MAL password'
-        }
 
         db_path = 'path/to/database'
 
-        robo = await Minoshiro.from_sqlite(mal_config, db_path)
+        robo = await Minoshiro.from_sqlite(db_path)
 
 
 To use the built in PostgreSQL support, you will need
@@ -37,10 +33,6 @@ Then, use the ``from_postgres`` method as such:
 
 
     async def main():
-        mal_config = {
-            'user': 'MAL User name',
-            'password': 'MAL password'
-        }
         db_config = {
             "host": "localhost",
             "port": "5432",
@@ -49,7 +41,7 @@ Then, use the ``from_postgres`` method as such:
         }
 
         robo = await Minoshiro.from_postgres(
-            mal_config, db_config, schema='my_schema'
+            db_config, schema='my_schema'
         )
 
 .. _Extending DatabaseController:
@@ -111,38 +103,6 @@ MUST be defined with ``async def``.
 
         :param identifier: the identifier.
         :type identifier: str
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    async def get_mal_title(self, id_: str, medium: Medium) -> Optional[str]:
-        """
-        Get a MAL title by its id.
-
-        :param id_: th MAL id.
-        :type id_: str
-
-        :param medium: the medium type.
-        :type medium: Medium
-
-        :return: The MAL title if it's found.
-        :rtype: Optional[str]
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    async def set_mal_title(self, id_: str, medium: Medium, title: str):
-        """
-        Set the MAL title for a given id.
-
-        :param id_: the MAL id.
-        :type id_: str
-
-        :param medium: The medium type.
-        :type medium: Medium
-
-        :param title: The MAL title for the given id.
-        :type title: str
         """
         raise NotImplementedError
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -15,11 +15,6 @@ PostgreSQL and SQLite3.
 
     from minoshiro import Medium, Minoshiro, Site
 
-    mal_config = {
-        'user': 'MAL User name',
-        'password': 'MAL password'
-    }
-
 
     async def postgres():
         postgres_config = {
@@ -30,8 +25,7 @@ PostgreSQL and SQLite3.
         }
 
         robo = await Minoshiro.from_postgres(
-            mal_config, postgres_config,
-            cache_pages=1, cache_mal_entries=30
+            postgres_config, cache_pages=1
         )
 
         # get_data eagerly evaluates all the data and return them in a dict
@@ -52,11 +46,11 @@ PostgreSQL and SQLite3.
         another_path = Path('another/sqlite/path')
 
         robo = await Minoshiro.from_sqlite(
-            mal_config, sqlite_path
+            sqlite_path
         )
 
         # We only want the results from those 2 sites.
-        sites = (Site.LNDB, Site.MAL)
+        sites = (Site.LNDB, Site.ANILIST)
         async for site, data in robo.get_data('overlord', Medium.LN, sites):
             print(site, data)
 

--- a/example.py
+++ b/example.py
@@ -2,11 +2,6 @@ from pathlib import Path
 
 from minoshiro import Medium, Minoshiro, Site
 
-mal_config = {
-    'user': 'MAL User name',
-    'password': 'MAL password'
-}
-
 
 async def postgres():
     postgres_config = {
@@ -17,8 +12,8 @@ async def postgres():
     }
 
     robo = await Minoshiro.from_postgres(
-        mal_config, postgres_config,
-        cache_pages=1, cache_mal_entries=30
+        postgres_config,
+        cache_pages=1,
     )
 
     # get_data eagerly evaluates all the data and return them in a dict
@@ -39,7 +34,7 @@ async def sqlite():
     another_path = Path('another/sqlite/path')
 
     robo = await Minoshiro.from_sqlite(
-        mal_config, sqlite_path
+        sqlite_path
     )
 
     # We only want the results from those 2 sites.
@@ -48,7 +43,7 @@ async def sqlite():
         print(site, data)
 
     another_robo = await Minoshiro.from_sqlite(
-        mal_config, another_path
+        another_path
     )
     # Specify the seconds for HTTP request timeout.
     print(
@@ -56,3 +51,5 @@ async def sqlite():
             'Love Live Sunshine!', Medium.ANIME, timeout=10
         )
     )
+
+await sqlite()

--- a/example.py
+++ b/example.py
@@ -51,5 +51,3 @@ async def sqlite():
             'Love Live Sunshine!', Medium.ANIME, timeout=10
         )
     )
-
-await sqlite()

--- a/minoshiro/pre_cache.py
+++ b/minoshiro/pre_cache.py
@@ -38,7 +38,7 @@ async def cache_top_pages(medium: Medium, session_manager: SessionManager,
     assert page_count > 0, 'Please enter a page count greater than 0.'
     await __cache(
         __n_popular_anilist(page_count, medium, session_manager, logger),
-        db, medium, mal_headers, session_manager, cache_mal_entries, logger
+        db, medium, logger
     )
 
 
@@ -61,11 +61,9 @@ async def __cache(async_iter, db, medium, mal_headers, session_manager,
 
     :param logger: the logger object.
     """
-    i = 0
     async for entry in async_iter:
         anilist_id = str(entry['id'])
         await db.set_medium_data(anilist_id, medium, Site.ANILIST, entry)
-
         romanji_name = entry.get('title_romaji')
         english_name = entry.get('title_english')
         anime_name = romanji_name or english_name
@@ -73,11 +71,6 @@ async def __cache(async_iter, db, medium, mal_headers, session_manager,
             continue
         for syn in get_synonyms(entry, Site.ANILIST):
             await db.set_identifier(syn, medium, Site.ANILIST, anilist_id)
-        if i < cache_mal_entries:
-            await __cache_mal_entry(
-                db, anime_name, medium, mal_headers, session_manager, logger
-            )
-            i += 1
 
 
 async def __n_popular_anilist(page_count: int, medium: Medium,

--- a/minoshiro/web_api/vndb.py
+++ b/minoshiro/web_api/vndb.py
@@ -1,0 +1,4 @@
+"""
+Queries VNDB for visual novels
+"""
+


### PR DESCRIPTION
Fixes #2. Deprecated MAL, I didn't delete any of the functions, I just commented them out so they wouldn't throw any compiler errors and I added a warning if someone uses `Site.MAL` in their {Sites} parameter. 

I'll be honest I didn't do **too** much testing, since it passed all the unit tests and it didn't break Discordoragi which is using it currently so feel free to test this out a bit more.